### PR TITLE
prevent starting service for redhat systems

### DIFF
--- a/sysstat/init.sls
+++ b/sysstat/init.sls
@@ -4,7 +4,9 @@ sysstat:
   pkg:
     - installed
     - name: {{ sysstat.pkg }}
+{% if grains['os_family'] != 'RedHat' %}
   service.running: 
     - enable: True
     - require:
       - pkg: sysstat
+{% endif %}


### PR DESCRIPTION
On RedHat and CentOS systems, sysstat is not invoked as a service but a cron job (default every 10 minutes). When starting the service, the init script runs sa1 --boot which creates an empty entry.

It doesn't really break anything but I think the correct approach on RedHat systems is to ignore the service because it is always stopped and Salt tries to start on every highstate run causing blank entries in the log.

``` shell
root@vagrant2~ # cat /etc/redhat-release
CentOS release 6.5 (Final)

root@vagrant2~ # rpm -qf /etc/cron.d/sysstat
sysstat-9.0.4-27.el6.x86_64

root@vagrant2 ~ # cat /etc/cron.d/sysstat
# Run system activity accounting tool every 10 minutes
*/10 * * * * root /usr/lib64/sa/sa1 1 1
#0 * * * * root /usr/lib64/sa/sa1 600 6 &
# Generate a daily summary of process accounting at 23:53
53 23 * * * root /usr/lib64/sa/sa2 -A
```
