### PR TITLE
Fixes typos map.jinja

### DIFF
--- a/sysstat/config.sls
+++ b/sysstat/config.sls
@@ -15,8 +15,8 @@ sysstat-config:
     - template: jinja
     - defaults:
         enabled: "{{ config_settings.enabled }}"
-        sa1_options: {{ config_settings.sa1_opts }}
-        sa2_options: {{ config_settings.sa2_opts }}
+        sa1_options: {{ config_settings.sa1_options }}
+        sa2_options: {{ config_settings.sa2_options }}
     {% if sysstat_settings.service.enabled %}
     - listen_in:
       - service: sysstat-service

--- a/sysstat/config.sls
+++ b/sysstat/config.sls
@@ -17,7 +17,7 @@ sysstat-config:
         enabled: "{{ config_settings.enabled }}"
         sa1_options: {{ config_settings.sa1_opts }}
         sa2_options: {{ config_settings.sa2_opts }}
-    {% if systat_settings.service.enabled %}
+    {% if sysstat_settings.service.enabled %}
     - listen_in:
       - service: sysstat-service
     {% endif %}

--- a/sysstat/map.jinja
+++ b/sysstat/map.jinja
@@ -5,22 +5,15 @@
 {% import_yaml 'sysstat/defaults.yml' as default_settings %}
 
 {## setup variable using grains['os_family'] based logic ##}
-{% set os_family_map = salt['grains.filter_by']({
+{% set sysstat_settings = salt['grains.filter_by']({
+        'Debian': default_settings.sysstat,
         'RedHat': {
             "service": {
                 "name": "sysstat",
                 "enabled": False
             }
         }
-  }, grain="os_family")
-%}
-{## Merge the flavor_map to the default settings ##}
-{% do default_settings.sysstat.update(os_family_map) %}
-
-{## Merge in sysstat:lookup pillar ##}
-{% set sysstat_settings = salt['pillar.get'](
-        'sysstat:lookup',
-        default=default_settings.sysstat,
-        merge=True
-    )
+    }, grain="os_family", default='Debian',
+    merge=salt['pillar.get']('sysstat:lookup')
+)
 %}

--- a/sysstat/package.sls
+++ b/sysstat/package.sls
@@ -4,7 +4,7 @@
 {## import settings from map.jinja ##}
 {% from "sysstat/map.jinja" import sysstat_settings with context %}
 
-systat-pkg:
+sysstat-pkg:
   pkg.installed:
-    - name: {{ systat_settings.pkg }}
+    - name: {{ sysstat_settings.pkg }}
     - failhard: True

--- a/sysstat/service.sls
+++ b/sysstat/service.sls
@@ -4,9 +4,9 @@
 {## import settings from map.jinja ##}
 {% from "sysstat/map.jinja" import sysstat_settings with context %}
 
-{% if systat_settings.service.enabled %}
-systat-service:
+{% if sysstat_settings.service.enabled %}
+sysstat-service:
   service.running:
-    - name: {{ systat_settings.service.name }}
+    - name: {{ sysstat_settings.service.name }}
     - enable: True
 {% endif %}


### PR DESCRIPTION
- Fix some typos
- Fix error in map.jijna (os_family_map was None for Debian family)
- Simplifies map.jinja according to common practice
