### PR TITLE
feat(yamllint): include for this repo and apply rules throughout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 ---
 stages:
   - test
-  - commitlint
+  - lint
   - name: release
     if: branch = master AND type != pull_request
 
@@ -45,16 +45,21 @@ script:
 
 jobs:
   include:
-    # Define the commitlint stage
-    - stage: commitlint
+    # Define the `lint` stage (runs `yamllint` and `commitlint`)
+    - stage: lint
       language: node_js
       node_js: lts/*
       before_install: skip
       script:
+        # Install and run `yamllint`
+        - pip install --user yamllint
+        # yamllint disable-line rule:line-length
+        - yamllint -s . .yamllint pillar.example
+        # Install and run `commitlint`
         - npm install @commitlint/config-conventional -D
         - npm install @commitlint/travis-cli -D
         - commitlint-travis
-    # Define the release stage that runs semantic-release
+    # Define the release stage that runs `semantic-release`
     - stage: release
       language: node_js
       node_js: lts/*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
+# Extend the `default` configuration provided by `yamllint`
+extends: default
+
+# Files to ignore completely
+# 1. All YAML files under directory `node_modules/`, introduced during the Travis run
+ignore: |
+  node_modules/
+
+rules:
+  line-length:
+    # Increase from default of `80`
+    # Based on https://github.com/PyCQA/flake8-bugbear#opinionated-warnings (`B950`)
+    max: 88

--- a/pillar.example
+++ b/pillar.example
@@ -4,7 +4,7 @@
 sysstat:
   version: '12.1.5'
   pkg:
-    use_upstream_source: False
+    use_upstream_source: false
     archive:
       uri: https://dl.sysstat.com/oss/release
 
@@ -38,12 +38,10 @@ sysstat:
     # dirs:
     #   files: files_alt
     #   default: default_alt
-    # source_files:
-    #   sysstat-config-file-file-managed:
-    #     - 'example_alt.tmpl'
-    #     - 'example_alt.tmpl.jinja'
+    source_files:
+      sysstat-config-file-file-managed-config_file:
+        - 'alt_sysstat.default.jinja'
 
   linux:
-    #'Alternatives system' priority: zero disables (default)
+    # 'Alternatives system' priority: zero disables (default)
     altpriority: 1000
-

--- a/sysstat/defaults.yaml
+++ b/sysstat/defaults.yaml
@@ -6,16 +6,18 @@ sysstat:
   version: '12.1.5'
   pkg:
     name: sysstat
-    use_upstream_source: False
+    use_upstream_source: false
     source:
       name: /tmp/sysstat
       uri: http://pagesperso-orange.fr/sebastien.godard
       source: None
-      source_hash: d3bbc90194326e93fbc7f63cff20894ea20cd05caee1bc6ada3bf602e06970e4  #linux amd64 tarball
-      trim_output: True   {# works in 2018.3.2. onwards #}
+      # linux amd64 tarball
+      source_hash: d3bbc90194326e93fbc7f63cff20894ea20cd05caee1bc6ada3bf602e06970e4
+      # works in 2018.3.2. onwards
+      trim_output: true
       archive_suffix: tar.gz
       archive_format: tar
-      enforce_toplevel: False
+      enforce_toplevel: false
       options: '--strip-components=1'
 
   kernel: ''
@@ -36,5 +38,5 @@ sysstat:
     name: sysstat
 
   linux:
-    #'Alternatives system' priority: zero disables (default)
+    # 'Alternatives system' priority: zero disables (default)
     altpriority: 0

--- a/sysstat/osfamilymap.yaml
+++ b/sysstat/osfamilymap.yaml
@@ -16,7 +16,7 @@ Debian: {}
 RedHat:
   service:
     name: sysstat
-    enabled: False
+    enabled: false
 
 Suse: {}
 

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+---
 name: default
 title: sysstat formula
 maintainer: SaltStack Formulas


### PR DESCRIPTION
* Semi-automated using `ssf-formula` (v0.5.0)
* Fix errors shown below:

```bash
sysstat-formula$ $(grep "\- yamllint" .travis.yml | sed -e "s:^\s\+-\s\(.*\):\1:")
./sysstat/defaults.yaml
  9:26      warning  truthy value should be one of [false, true]  (truthy)
  14:87     warning  missing starting space in comment  (comments)
  14:89     error    line too long (105 > 88 characters)  (line-length)
  15:57     warning  too few spaces before comment  (comments)
  15:58     warning  missing starting space in comment  (comments)
  18:25     warning  truthy value should be one of [false, true]  (truthy)
  39:6      warning  missing starting space in comment  (comments)

./sysstat/osfamilymap.yaml
  19:14     warning  truthy value should be one of [false, true]  (truthy)

pillar.example
  7:26      warning  truthy value should be one of [false, true]  (truthy)
  35:5      warning  comment not indented like content  (comments-indentation)
  47:6      warning  missing starting space in comment  (comments)
  49:1      error    too many blank lines (1 > 0)  (empty-lines)
```

---

Refer back to: https://github.com/saltstack-formulas/template-formula/pull/159#issue-305203039.