### PR TITLE
chore: use `semantic-release` cross-formula standard structure

### DIFF
--- a/sysstat/libtofs.jinja
+++ b/sysstat/libtofs.jinja
@@ -2,7 +2,7 @@
                        lookup=None,
                        default_files_switch=['id', 'os_family'],
                        indent_width=6,
-                       v1_path_prefix='') %}
+                       use_subpath=False) %}
   {#-
     Returns a valid value for the "source" parameter of a "file.managed"
     state function. This makes easier the usage of the Template Override and
@@ -17,8 +17,8 @@
         use as selector switch of the directories under
         "<path_prefix>/files"
       * indent_witdh: indentation of the result value to conform to YAML
-      * v1_path_prefix: (deprecated) only used for injecting a path prefix into
-        the source, to support older TOFS configs
+      * use_subpath: defaults to `False` but if set, lookup the source file
+        recursively from the current state directory up to `tplroot`
 
     Example (based on a `tplroot` of `xxx`):
 
@@ -64,10 +64,15 @@
   {%- set src_files = src_files + source_files %}
   {#- Only add to [''] when supporting older TOFS implementations #}
   {%- set path_prefix_exts = [''] %}
-  {%- if v1_path_prefix != '' %}
-    {%- do path_prefix_exts.append(v1_path_prefix) %}
+  {%- if use_subpath and tplroot != tpldir %}
+    {#- Walk directory tree to find {{ files_dir }} #}
+    {%- set subpath_parts = tpldir.lstrip(tplroot).lstrip('/').split('/') %}
+    {%- for path in subpath_parts %}
+      {%- set subpath = subpath_parts[0:loop.index] | join('/') %}
+      {%- do path_prefix_exts.append('/' ~ subpath) %}
+    {%- endfor %}
   {%- endif %}
-  {%- for path_prefix_ext in path_prefix_exts %}
+  {%- for path_prefix_ext in path_prefix_exts|reverse %}
     {%- set path_prefix_inc_ext = path_prefix ~ path_prefix_ext %}
     {#- For older TOFS implementation, use `files_switch` from the config #}
     {#- Use the default, new method otherwise #}


### PR DESCRIPTION
* Automated using `ssf-formula` (v0.6.0)